### PR TITLE
Swapping two variables using c

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+
+void swap(int x, int y){
+    int temp = x;
+    x = y;
+    y = temp;
+}
+//call by value
+int main(){
+    int x = 10;
+    int y = 11;
+    printf("Values before swap: x = %d, y = %d\n", x,y);
+    swap(x,y);
+    printf("Values after swap: x = %d, y = %d", x,y);
+}
+
+#include <stdio.h>
+
+void swap(int *x, int *y){
+    int temp = *x;
+    *x = *y;
+    *y = temp;
+}
+//call by reference
+int main(){
+    int x = 10;
+    int y = 11;
+    printf("Values before swap: x = %d, y = %d\n", x,y);
+    swap(&x,&y);
+    printf("Values after swap: x = %d, y = %d", x,y);
+}


### PR DESCRIPTION
Call by value:
We can observe that even when we change the content of x and y in the scope of the swap function, these changes does not reflect on x and y variables defined in the scope of main. This is because we call swap() by value and it will get separate memory for x and y so the changes made in swap() will not reflect in main(). Call by reference:
We can observe in function parameters instead of using int x,int y we used int *x,int *y and in function call instead of giving x,y we give &x,&y this methodology is call by reference as we used pointers as function parameter which will get original parameters address instead of their value. & operator is used to give address of the variables and * is used to access the memory location that pointer is pointing. As the function variable is pointing to same memory location as original parameter the changes made in swap() reflect in main() which we could see in the above output.